### PR TITLE
Fixed two small bugs

### DIFF
--- a/Data Generation Prototype.ipynb
+++ b/Data Generation Prototype.ipynb
@@ -128,7 +128,7 @@
     "                                               centers=num_labels)\n",
     "    \n",
     "    df = pd.DataFrame(feat_arr)\n",
-    "    evenly_add_labels_to_data(df, num_samples, num_features)\n",
+    "    df['labels'] = label_idxs\n",
     "    return df"
    ]
   },
@@ -158,7 +158,7 @@
     "        feat_arr = np.random.ranf(num_samples) * RAND_FEAT_RANGE\n",
     "        df[i] = feat_arr\n",
     "    \n",
-    "    evenly_add_labels_to_data(df, num_samples, num_features)\n",
+    "    evenly_add_labels_to_data(df, num_samples, num_labels)\n",
     "    return df\n"
    ]
   },


### PR DESCRIPTION
Two fixes for two small bugs discovered by Dave.

- Fixed calling `evenly_add_labels_to_data` in `gen_blob_data` when we
already had labels.
- Fixed `evenly_add_labels_to_data` taking in `num_features` instead of
`num_labels`.