### PR TITLE
Initial .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.ipynb_checkpoints/
+


### PR DESCRIPTION
For now just contains some generated jupyter file types, but we definitely will need more later.