### PR TITLE
Runner random seed param

### DIFF
--- a/Using the Runner.ipynb
+++ b/Using the Runner.ipynb
@@ -89,6 +89,7 @@
     "    Runner.P_KEY_NUM_ROUNDS: 10,\n",
     "    Runner.P_KEY_BATCH_SIZE: 40,\n",
     "    Runner.P_KEY_NUM_EPOCHS: 5,\n",
+    "    Runner.P_KEY_RAND_SEED: 42,\n",
     "    Runner.P_KEY_DATA_FILE_PATH: blob_data_file_path\n",
     "}\n",
     "\n",

--- a/mozfldp/runner.py
+++ b/mozfldp/runner.py
@@ -46,6 +46,7 @@ def run_fed_learn_sim(s_prms, data):
     num_rounds = s_prms[Runner.P_KEY_NUM_ROUNDS]
     batch_size = s_prms[Runner.P_KEY_BATCH_SIZE]
     num_epochs = s_prms[Runner.P_KEY_NUM_EPOCHS]
+    rand_seed = s_prms[Runner.P_KEY_RAND_SEED]
 
     # Note: data is already transformed for sim format
 
@@ -55,7 +56,7 @@ def run_fed_learn_sim(s_prms, data):
 
     # Split the data into training and testing sets
     X_train, X_test, y_train, y_test = train_test_split(
-        features, labels, test_size=0.4, random_state=0
+        features, labels, test_size=0.4, random_state=rand_seed
     )
 
     init_weights = np.zeros((num_labels, num_features), dtype=np.float64, order="C")
@@ -83,6 +84,7 @@ def run_fed_learn_sim(s_prms, data):
             params["epoch"],
             params["batch_size"],
             False,
+            rand_seed,
         )
         weights = [classifier.coef_, classifier.intercept_]
 
@@ -126,6 +128,7 @@ class Runner:
     P_KEY_NUM_ROUNDS = "num_rounds"
     P_KEY_BATCH_SIZE = "batch_size"
     P_KEY_NUM_EPOCHS = "num_epochs"
+    P_KEY_RAND_SEED = "rand_seed"
 
     _sim_run_func_ltable = {
         SIM_TYPE_FED_LEARNING: (
@@ -137,6 +140,7 @@ class Runner:
                 P_KEY_NUM_SAMPLES,
                 P_KEY_NUM_FEATURES,
                 P_KEY_NUM_USERS,
+                P_KEY_RAND_SEED,
             },
         ),
         SIM_TYPE_FED_AVG_WITH_DP: (


### PR DESCRIPTION
(Hopefully) fixes all non-determinism for the fed avg sim. While I can't currently verify that multiple runs produce the same results (since Maharsh is still working on the sim), I've tested these changes on an older runnable version of this sim and verified that multiple runs did in fact produce identical weights.

Other notes:
- I didn't do a Python Black pass because it adds a bunch of unrelated noise to the commits and may make it harder for Maharsh to merge later on.
- Also added a new parameter to the runner (`P_KEY_RAND_SEED`).