### PR TITLE
Fixed README.md instructions on running non-docker server

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ docker build . -t mozfldp:latest
 You can run the server locally serving requests on port 8000 using:
 
 ```
-python mozfldp/server.py
+python -m mozfldp.server
 ```
 
 Alternately, you can run the service in a container using :


### PR DESCRIPTION
- Running `python mozfldp/server.py` fails to start the server because `server.py` has this import: `from mozfldp.simulation_util import server_update`. The problem with this is when we run `python mozfldp/server.py`, `server.py` becomes the "root" and calls like involving the parent directory `mozfldp` can't be resolved.
- Instead, if we pass in the `m` flag when we call Python, `mozfldp` is in scope and the import doesn't break.

If I'm missing something let me know.