### PR TITLE
Simulation architecture refactor

### DIFF
--- a/mozfldp/client.py
+++ b/mozfldp/client.py
@@ -47,8 +47,8 @@ class Client:
 
         # TODO: update weights across batches and epochs.
         for epoch in range(num_epochs):
-            for i in range(num_batches):
-                self._run_model_update_step(batch_features[i], batch_labels[i])
+            for i in range(batch_size):
+                self._run_model_update_step(self._features[i], self._labels[i])
 
         # TODO: submit new weights to the server via API request.
         # self._model.get_weights() -> server

--- a/mozfldp/client.py
+++ b/mozfldp/client.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+class Client:
+    """A client which trains model updates on its personal dataset for FL.
+
+    features: an array of shape (`n_examples`, `n_features`) containing the
+        client's personal dataset features
+    labels: an array of shape (`n_features`) containing the client's personal
+        dataset labels
+    model: a `SGDModel` instance to be used for training
+    """
+
+    def __init__(self, features, labels, model):
+        self._features = features
+        self._labels = labels
+        self._model = model
+
+    def _get_batch_indices(self, batch_size):
+        """Randomly split data into minibatches of target size `batch_size`.
+
+        Returns a list `[(i_1_1, i_1_2, ..., i_1_b), (i_2_1, ..., i_2_b), ...]`
+        of length `len(features) // batch_size` containing index sets for each
+        batch.
+        """
+        # TODO
+        pass
+
+    def update_and_submit_weights(self, current_weights, num_epochs, batch_size):
+        """Update the current model weights for FL using the client's data.
+
+        Resulting weights are submitted to the server.
+        """
+        # TODO
+        pass
+
+    def update_and_submit_weights_dp(self, current_weights, num_epochs, batch_size):
+        """Update the current model weights for FL with DP using the client's data.
+
+        Resulting weights are submitted to the server.
+        """
+        # TODO
+        pass

--- a/mozfldp/client.py
+++ b/mozfldp/client.py
@@ -27,15 +27,29 @@ class Client:
         # TODO
         pass
 
-    def update_and_submit_weights(self, current_weights, num_epochs, batch_size):
+    def _run_model_update_step(self, X, y):
+        """Run a single GD update step on the given data minibatch."""
+        self._model.minibatch_update(X, y)
+
+    def update_and_submit_weights(self, current_coef, current_intercept, num_epochs, batch_size):
         """Update the current model weights for FL using the client's data.
 
         Resulting weights are submitted to the server.
         """
-        # TODO
-        pass
+        self._model.set_weights(current_coef, current_intercept)
 
-    def update_and_submit_weights_dp(self, current_weights, num_epochs, batch_size):
+        # TODO: split data into batches.
+
+        # TODO: update weights across batches and epochs.
+        for epoch in range(num_epochs):
+            for i in range(num_batches):
+                self._run_model_update_step(batch_features[i], batch_labels[i])
+
+        # TODO: submit new weights to the server via API request.
+        # self._model.get_weights() -> server
+
+
+    def update_and_submit_weights_dp(self, current_coef, current_intercept, num_epochs, batch_size):
         """Update the current model weights for FL with DP using the client's data.
 
         Resulting weights are submitted to the server.

--- a/mozfldp/client.py
+++ b/mozfldp/client.py
@@ -2,6 +2,8 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+import numpy as np
+
 
 class Client:
     """A client which trains model updates on its personal dataset for FL.
@@ -9,26 +11,33 @@ class Client:
     client_id: a unique ID to assign each client
     features: an array of shape (`n_examples`, `n_features`) containing the
         client's personal dataset features
-    labels: an array of shape (`n_features`) containing the client's personal
+    labels: an array of shape (`n_examples`) containing the client's personal
         dataset labels
     model: a `SGDModel` instance to be used for training
     """
 
     def __init__(self, client_id, features, labels, model):
+        if not features.shape[0] == len(labels):
+            raise ValueError(
+                "Features and labels have incompatible shapes for client {}".format(
+                    client_id
+                )
+            )
+
         self._id = client_id
         self._features = features
         self._labels = labels
         self._model = model
+        self._n = len(labels)
 
     def _get_batch_indices(self, batch_size):
         """Randomly split data into minibatches of target size `batch_size`.
 
-        Returns a list `[(i_1_1, i_1_2, ..., i_1_b), (i_2_1, ..., i_2_b), ...]`
-        of length `len(features) // batch_size` containing index sets for each
-        batch.
+        Returns a list of length `ceiling(self._n / batch_size)` containing
+        index lists for each batch.
         """
-        # TODO
-        pass
+        shuffled_ind = np.random.permutation(self._n)
+        return [shuffled_ind[i : i + batch_size] for i in range(0, self._n, batch_size)]
 
     def _run_model_update_step(self, X, y):
         """Run a single GD update step on the given data minibatch."""

--- a/mozfldp/client.py
+++ b/mozfldp/client.py
@@ -48,16 +48,21 @@ class Client:
     ):
         """Update the current model weights for FL using the client's data.
 
+        current_coef: current model coefficients to start from
+        current_intercept: current model intercept to start from
+        num_epochs: number of passes through the client data
+        batch_size: size of data minibatch used in each weight update step
+
         Resulting weights are submitted to the server.
         """
         self._model.set_weights(current_coef, current_intercept)
 
-        # TODO: split data into batches.
-
-        # TODO: update weights across batches and epochs.
+        batch_ind_list = self._get_batch_indices(batch_size)
         for epoch in range(num_epochs):
-            for i in range(num_batches):
-                self._run_model_update_step(batch_features[i], batch_labels[i])
+            for batch_ind in batch_ind_list:
+                self._run_model_update_step(
+                    self._features[batch_ind], self._labels[batch_ind]
+                )
 
         # TODO: submit new weights to the server via API request.
         # self._model.get_weights() -> server

--- a/mozfldp/client.py
+++ b/mozfldp/client.py
@@ -6,6 +6,7 @@
 class Client:
     """A client which trains model updates on its personal dataset for FL.
 
+    client_id: a unique ID to assign each client
     features: an array of shape (`n_examples`, `n_features`) containing the
         client's personal dataset features
     labels: an array of shape (`n_features`) containing the client's personal
@@ -13,7 +14,8 @@ class Client:
     model: a `SGDModel` instance to be used for training
     """
 
-    def __init__(self, features, labels, model):
+    def __init__(self, client_id, features, labels, model):
+        self._id = client_id
         self._features = features
         self._labels = labels
         self._model = model

--- a/mozfldp/client.py
+++ b/mozfldp/client.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
 class Client:
     """A client which trains model updates on its personal dataset for FL.
 
@@ -31,7 +32,9 @@ class Client:
         """Run a single GD update step on the given data minibatch."""
         self._model.minibatch_update(X, y)
 
-    def update_and_submit_weights(self, current_coef, current_intercept, num_epochs, batch_size):
+    def update_and_submit_weights(
+        self, current_coef, current_intercept, num_epochs, batch_size
+    ):
         """Update the current model weights for FL using the client's data.
 
         Resulting weights are submitted to the server.
@@ -48,8 +51,9 @@ class Client:
         # TODO: submit new weights to the server via API request.
         # self._model.get_weights() -> server
 
-
-    def update_and_submit_weights_dp(self, current_coef, current_intercept, num_epochs, batch_size):
+    def update_and_submit_weights_dp(
+        self, current_coef, current_intercept, num_epochs, batch_size
+    ):
         """Update the current model weights for FL with DP using the client's data.
 
         Resulting weights are submitted to the server.

--- a/mozfldp/model.py
+++ b/mozfldp/model.py
@@ -4,17 +4,25 @@
 
 from sklearn.linear_model import SGDClassifier
 from sklearn.base import clone
+from sklearn.utils.multiclass import unique_labels
+
 import copy
 
 class SGDModel:
     """Wrapper around `scikit-learn`'s SGD classifier allowing for external
     updating of model weights and a modified training interface.
 
-    kwargs supplied to the constructor are passed to the underlying classifier.
+    all_training_labels: the labels in the training data (doesn't need to be
+        unique). This is needed to enable `partial_fit`.
+
+    Other kwargs supplied to the constructor are passed to the underlying
+    classifier.
     """
     
-    def __init__(self, **kwargs):
+    def __init__(self, all_training_labels, **kwargs):
         self.classifier = SGDClassifier(**kwargs)
+        self.classifier.classes_ = unique_labels(all_training_labels)
+
 
     def get_clone(self, trained=False):
         """Create a clone of this classifier.

--- a/mozfldp/model.py
+++ b/mozfldp/model.py
@@ -1,0 +1,46 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from sklearn.linear_model import SGDClassifier
+from sklearn.base import clone
+import copy
+
+class SGDModel:
+    """Wrapper around `scikit-learn`'s SGD classifier allowing for external
+    updating of model weights and a modified training interface.
+
+    kwargs supplied to the constructor are passed to the underlying classifier.
+    """
+    
+    def __init__(self, **kwargs):
+        self.classifier = SGDClassifier(**kwargs)
+
+    def get_clone(self, trained=False):
+        """Create a clone of this classifier.
+
+        trained: if `True`, maintains current state including trained model
+            weights, interation counter, etc. Otherwise, returns an unfitted
+            model with the same initialization params.
+        """
+        if trained:
+            new_classifier = copy.deepcopy(self.classifier)
+        else:
+            new_classifier = clone(self.classifier)
+
+        new_model = self.__class__()
+        new_model.classifier = new_classifier
+        return new_model
+
+    def __repr__(self):
+        return "SGDModel(\n{}\n)".format(self.classifier.__repr__())
+
+    def set_weights(self, coef, intercept):
+        """Update the current model weights."""
+        self.classifier.coef_ = coef
+        self.classifier.intercept_ = intercept
+
+    def minibatch_update(self, X, y):
+        """Run a single weight update on the given minibatch."""
+        # TODO: implement. Need to consider how to set `t_` and `n_iter_`
+        pass

--- a/mozfldp/model.py
+++ b/mozfldp/model.py
@@ -8,6 +8,7 @@ from sklearn.utils.multiclass import unique_labels
 
 import copy
 
+
 class SGDModel:
     """Wrapper around `scikit-learn`'s SGD classifier allowing for external
     updating of model weights and a modified training interface.
@@ -18,11 +19,10 @@ class SGDModel:
     Other kwargs supplied to the constructor are passed to the underlying
     classifier.
     """
-    
+
     def __init__(self, all_training_labels, **kwargs):
         self.classifier = SGDClassifier(**kwargs)
         self.classifier.classes_ = unique_labels(all_training_labels)
-
 
     def get_clone(self, trained=False):
         """Create a clone of this classifier.

--- a/mozfldp/model.py
+++ b/mozfldp/model.py
@@ -44,9 +44,17 @@ class SGDModel:
         return "SGDModel(\n{}\n)".format(self.classifier.__repr__())
 
     def set_weights(self, coef, intercept):
-        """Update the current model weights."""
+        """Update the current model weights.
+
+        Note that this leaves the iteration counters as-is. These are used
+        internally in computing an adaptive learning rate.
+        """
         self.classifier.coef_ = coef
         self.classifier.intercept_ = intercept
+
+    def get_weights(self):
+        """Return the current model weights as (coef, intercept)."""
+        return (self.classifier.coef_, self.classifier.intercept_)
 
     def minibatch_update(self, X, y):
         """Run a single weight update on the given minibatch."""

--- a/mozfldp/model.py
+++ b/mozfldp/model.py
@@ -57,6 +57,10 @@ class SGDModel:
         return (self.classifier.coef_, self.classifier.intercept_)
 
     def minibatch_update(self, X, y):
-        """Run a single weight update on the given minibatch."""
+        """Run a single weight update on the given minibatch.
+
+        X and y should be arrays of the appropriate dimensions as required by
+        `SGDClassifier.fit()`.
+        """
         # TODO: implement. Need to consider how to set `t_` and `n_iter_`
         pass

--- a/mozfldp/simulation_runner.py
+++ b/mozfldp/simulation_runner.py
@@ -1,0 +1,140 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from mozfldp.client import Client
+
+# TODO: how should this be invoked?
+from mozfldp.server import start_server
+
+import numpy as np
+
+
+def _format_data_for_model(dataset, label_col, user_id_col):
+    """Split a DataFrame into feature & label arrays."""
+    if not dataset:
+        return (None, None)
+    if user_id_col in dataset.columns:
+        dataset = dataset.drop(columns=user_id_col)
+    return (np.asarray(dataset.drop(columns=label_col)), np.asarray(dataset[label_col]))
+
+
+class BaseSimulationRunner:
+    """Manager for the server/client simulation infrastructure.
+
+    On initialization, the data is allocated across clients.
+    Individual simulation rounds can then be performed using
+    `run_simulation_round()`.
+
+    model: a `SGDModel` instance to be used for the simulation
+    training_data: a DataFrame containing the full training data. It should have
+        columns indicating a user ID and training labels. All other columns are
+        considered to be features
+    coef_init: the initial choice for the model coefficients
+    intercept_init: the initial choice for the model intercept
+    test_data: a DataFrame in the same format as `training_data`
+    label_col: name of the column containing labels
+    user_id_col: name of the column containing user IDs
+    """
+
+    def __init__(
+        self,
+        model,
+        training_data,
+        coef_init,
+        intercept_init,
+        test_data=None,
+        label_col="labels",
+        user_id_col="user_id",
+    ):
+        self._model = model
+        # Maintain the history of model weights for each round.
+        self._coefs = [coef_init]
+        self._intercepts = [intercept_init]
+        self._num_rounds_completed = 0
+
+        # Initialize the clients with their respective datasets.
+        self._clients = []
+        by_user_data = training_data.groupby("user_id")
+        for user_id, user_data in by_user_data:
+            feats, labs = _format_data_for_model(user_data, label_col, user_id_col)
+            self._clients.append(Client(user_id, feats, labs, self._model.get_clone()))
+
+        # Format the test data into features/labels arrays, if provided.
+        self._test_data_features, self._test_data_labels = _format_data_for_model(
+            test_data, label_col, user_id_col
+        )
+
+        # Initialize the server.
+        # TODO: how should this be handled?
+        self._server = start_server()
+
+    def run_simulation_round(self):
+        """Perform a single round of model training.
+
+        At the base level, just increment the round counter.
+        """
+        self._num_rounds_completed += 1
+
+
+class FLSimulationRunner(BaseSimulationRunner):
+    """Simulation runner for standard federated learning.
+
+    In addition to model, data and initial weights, supply:
+
+    num_epochs: number of passes through each client's dataset on each round.
+    client_fraction: target fraction of clients on which to run updates on each
+        round.
+    batch_size: target size of client minibatches. Weights are updated once per
+        minibatch on each client in a given round.
+    kwargs: other args passed to BaseSimulationRunner
+    """
+
+    def __init__(self, num_epochs, client_fraction, batch_size, **kwargs):
+        self._num_epochs = num_epochs
+        self._client_fraction = client_fraction
+        self._batch_size = batch_size
+
+        super().__init__(**kwargs)
+
+    def run_simulation_round(self):
+        """Perform a single round of federated learning."""
+        # TODO finish implementing this. Should it return the current weights?
+        for client in self._clients:
+            if np.random.random_sample() < self._client_fraction:
+                client.update_and_submit_weights(
+                    self._coefs[-1],
+                    self._intercepts[-1],
+                    self._num_epochs,
+                    self._batch_size,
+                )
+
+        new_coef, new_intercept = self._server.compute_new_weights()
+        self._coefs.append(new_coef)
+        self._intercepts.append(new_intercept)
+
+        ## Increment the round counter.
+        super().run_simulation_round()
+
+        return new_coef, new_intercept
+
+
+class FLDPSimulationRunner(BaseSimulationRunner):
+    """Simulation runner for federated learning with DP.
+
+    In addition to model, data and initial weights, supply:
+
+    num_epochs: number of passes through each client's dataset on each round.
+    client_fraction: target fraction of clients on which to run updates on each
+        round.
+    batch_size: target size of client minibatches. Weights are updated once per
+        minibatch on each client in a given round.
+    sensitivity: limit on the change in weights from a client update
+    noise_scale: desired noise scale. Controls the amount of privacy budget
+        spent on each round.
+    user_weight_cap: limit on the influence of a single user in the federated
+        averaging
+    kwargs: other args passed to BaseSimulationRunner
+    """
+
+    pass

--- a/mozfldp/simulation_runner.py
+++ b/mozfldp/simulation_runner.py
@@ -118,7 +118,7 @@ class FLSimulationRunner(BaseSimulationRunner):
         self._coefs.append(new_coef)
         self._intercepts.append(new_intercept)
 
-        ## Increment the round counter.
+        # Increment the round counter.
         super().run_simulation_round()
 
         return new_coef, new_intercept

--- a/mozfldp/simulation_runner.py
+++ b/mozfldp/simulation_runner.py
@@ -48,6 +48,9 @@ class BaseSimulationRunner:
         user_id_col="user_id",
     ):
         self._model = model
+        # Make the model aware of the full set of labels (necessary for partial
+        # fit updating).
+        self._model.set_training_classes(training_data[label_col])
         # Maintain the history of model weights for each round.
         self._coefs = [coef_init]
         self._intercepts = [intercept_init]

--- a/mozfldp/simulation_runner.py
+++ b/mozfldp/simulation_runner.py
@@ -61,7 +61,9 @@ class BaseSimulationRunner:
         by_user_data = training_data.groupby("user_id")
         for user_id, user_data in by_user_data:
             feats, labs = _format_data_for_model(user_data, label_col, user_id_col)
-            self._clients.append(Client(user_id, feats, labs, self._model.get_clone()))
+            self._clients.append(
+                Client(user_id, feats, labs, self._model.get_clone(trained=True))
+            )
 
         # Format the test data into features/labels arrays, if provided.
         self._test_data_features, self._test_data_labels = _format_data_for_model(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,19 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+def test_batching():
+    # TODO: batching works as expected:
+    # right number of batches of the right sizes
+    pass
+
+
+def test_update_weights():
+    # TODO: check weights and iteration counters t_, n_iter_ for correctness.
+    pass
+
+
+def test_update_weights_dp():
+    pass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -62,20 +62,28 @@ def reset_random_seed():
     np.random.seed(42)
 
 
+def compare_batch_indices(actual, expected):
+    assert len(actual) == len(expected)
+    for act, exp in zip(actual, expected):
+        assert np.array_equal(act, exp)
+
+
 def test_batching(client, batched_indices_2, batched_indices_3):
     reset_random_seed()
     # Batch size divides data evenly.
     batches_size_div = client._get_batch_indices(2)
-    assert len(batches_size_div) == len(batched_indices_2)
-    for actual, expected in zip(batches_size_div, batched_indices_2):
-        assert np.array_equal(actual, expected)
+    compare_batch_indices(batches_size_div, batched_indices_2)
 
     reset_random_seed()
     # Batch size does not divide data evenly.
     batches_size_nondiv = client._get_batch_indices(3)
-    assert len(batches_size_nondiv) == len(batched_indices_3)
-    for actual, expected in zip(batches_size_nondiv, batched_indices_3):
-        assert np.array_equal(actual, expected)
+    compare_batch_indices(batches_size_nondiv, batched_indices_3)
+
+    reset_random_seed()
+    # If batch size exceeds data size, all data should be in a single batch.
+    batches_size_exceed = client._get_batch_indices(20)
+    batch_ind = [np.ravel(batched_indices_2)]
+    compare_batch_indices(batches_size_exceed, batch_ind)
 
 
 def test_update_weights(client, monkeypatch, batched_indices_2):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,12 +3,46 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import pytest
+import numpy as np
+
+from mozfldp.client import Client
+
+
+def check_batch_indices(batch_ind, data_n, main_batch_size, final_batch_size):
+    # batch_ind is a list containing index lists.
+    all_ind = np.concatenate(batch_ind)
+    # indices in batch_ind should cover 0, 1, ..., n-1.
+    assert len(np.setxor1d(all_ind, np.arange(data_n))) == 0
+    # number of batches:
+    assert len(batch_ind) == np.ceil(data_n / main_batch_size)
+    # all index lists should be of the same size, except possibly the last one.
+    for i in range(len(batch_ind) - 1):
+        assert len(batch_ind[i]) == main_batch_size
+    assert len(batch_ind[-1]) == final_batch_size
 
 
 def test_batching():
-    # TODO: batching works as expected:
-    # right number of batches of the right sizes
-    pass
+    features = np.array(
+        [
+            [6, 9, 6],
+            [9, 2, 8],
+            [0, 5, 4],
+            [2, 6, 1],
+            [6, 8, 1],
+            [6, 1, 6],
+            [5, 8, 5],
+            [7, 6, 6],
+        ]
+    )
+    labels = np.array([1, 0, 1, 0, 1, 0, 1, 0])
+
+    client = Client(client_id=None, features=features, labels=labels, model=None)
+
+    batches_size_div = client._get_batch_indices(2)
+    check_batch_indices(batches_size_div, 8, 2, 2)
+
+    batches_size_nondiv = client._get_batch_indices(3)
+    check_batch_indices(batches_size_nondiv, 8, 3, 2)
 
 
 def test_update_weights():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+
 def test_batching():
     # TODO: batching works as expected:
     # right number of batches of the right sizes

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,4 +14,5 @@ def test_get_clone():
 
 
 def test_minibatch_update():
+    # TODO: check weights and iteration counters t_, n_iter_ for correctness.
     pass

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+
 def test_get_clone():
     # TODO: get_clone(trained=False) should return an object with the same
     # initialization params but missing coef_/intercept_/t_.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pytest
+
+def test_get_clone():
+    # TODO: get_clone(trained=False) should return an object with the same
+    # initialization params but missing coef_/intercept_/t_.
+    # get_clone(trained=True) should return an object for which
+    # classifier.__getstate__() returns the same as for the original one.
+    pass
+
+
+def test_minibatch_update():
+    pass

--- a/tests/test_simulation_util.py
+++ b/tests/test_simulation_util.py
@@ -4,6 +4,7 @@
 
 import pytest
 
+
 def test_simulation_util():
     pass
 


### PR DESCRIPTION
This continues the refactoring in #36 of the simulation runner to an actual client-server model. The new design is outlined across a few new classes, but details still need to be filled in.

Summary of changes:

- `Client` class to encapsulate client data and manage weight updates individually
- `SGDModel` class to wrap the sklearn model. This lets model params get set once in the notebook where the simulation is run from and get shared around by cloning. We can also develop an interface to training which is better adapted to our needs, ie updating model weights on the fly and minibatch updating.
- Simulation runner redesign. Changes from `runner.py`:
  * Data loading will be handled in the notebook where the simulation is run from
  * Model and initial weights are initialized in the notebook
  * Params can be handled more simply and transparently using keyword args. This will also throw errors automatically if required params are missing.
  * Most of `run_fed_learn_sim` will get relegated to the calling notebook, ie. train/test split, weight initialization, specifying the param grid, validation, etc. (still in progress)
- Sketch of test cases