### PR TITLE
Fixed notebooks being unrunnable because of inaccessible modules

### DIFF
--- a/notebooks/Data Generation Prototype.ipynb
+++ b/notebooks/Data Generation Prototype.ipynb
@@ -30,6 +30,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import notebook_import_fix\n",
+    "\n",
     "# Likely not needed...\n",
     "%matplotlib inline\n",
     "\n",

--- a/notebooks/Federated_Learning_Simulation.ipynb
+++ b/notebooks/Federated_Learning_Simulation.ipynb
@@ -10,6 +10,7 @@
    },
    "outputs": [],
    "source": [
+    "import notebook_import_fix\n",
     "from sklearn.linear_model import SGDClassifier\n",
     "import numpy as np\n",
     "from mozfldp.simulation_util import client_update\n",

--- a/notebooks/Using the Runner.ipynb
+++ b/notebooks/Using the Runner.ipynb
@@ -33,6 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import notebook_import_fix\n",
     "from mozfldp.runner import Runner\n",
     "import warnings\n",
     "\n",

--- a/notebooks/notebook_import_fix.py
+++ b/notebooks/notebook_import_fix.py
@@ -1,0 +1,13 @@
+# Borrowed from here: https://stackoverflow.com/a/35273613
+
+"""
+When imported, this module makes sure CANOSP-2019 is in sys.path.
+All notebooks that rely on modules defined in the project should have this as their first import!
+"""
+
+import os
+import sys
+
+module_path = os.path.abspath(os.path.join('..'))
+if module_path not in sys.path:
+    sys.path.append(module_path)


### PR DESCRIPTION
- Caused by moving notebooks into their own directory (`notebooks`) and being unable to access anything outside of it.

Relevant commit: 1e9000423e9a91b2d08efbdf72fe6ce5317017b7