### PR TITLE
Add in privacy accounting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -65,6 +65,7 @@ scikit-learn==0.21.3
 scipy==1.3.1
 Send2Trash==1.5.0
 six==1.12.0
+tensorflow-privacy==0.2.2
 terminado==0.8.2
 testpath==0.4.2
 tornado==6.0.3


### PR DESCRIPTION
Turns out we can just import the privacy computation library from TensorFlow. The accounting can be handled at the level of the simulation runner, since it doesn't depend on the actual data or model weights, only the simulation parameters.